### PR TITLE
Bug fix - incentives URL return 404

### DIFF
--- a/SolarCalc/static/incentivesScript.js
+++ b/SolarCalc/static/incentivesScript.js
@@ -60,7 +60,7 @@ function populateIncentivesTable(jsonResponse)
 
         cell1.innerHTML = category;
         cell2.innerHTML = name;
-        cell3.innerHTML = '<a href="url">' + url + '</a>';
+        cell3.innerHTML = "<a href=" + url + ">" + url + "</a>";
         cell4.innerHTML = type;
     }
 }


### PR DESCRIPTION
Incentives URL's were a returning a 404 - not found. This was because URL was being passed into the table as a string 'url' rather than var url. Fixed this by concatenating url as variable to the string for <a href> element.